### PR TITLE
Why allow to specify different nx and ny when this leads to segfault?

### DIFF
--- a/serial_mandelbrot.c
+++ b/serial_mandelbrot.c
@@ -13,7 +13,7 @@
 
 void calc_pixel_value(int calcny, int calcnx, int calcMSet[calcnx*calcny], int calcmaxiter);
 
-void main(int argc, int *argv[])
+int main(int argc, char *argv[])
 {
 	//Here we create a 1 dimensional array that will be the total size of the image (in pixels). Because
 	//this array can get so big, we need to declare it on the heap and NOT the stack (i.e. how one would normally
@@ -64,7 +64,7 @@ void main(int argc, int *argv[])
 			xder = 0.0;
 			yder = 0.0;
 			dist = 0.0;
-			cx = xmin +ix*(xmax-xmin)/(double)(ny-1);
+			cx = xmin +ix*(xmax-xmin)/(double)(nx-1);
 			//This is the main loop that determins whether or not the point escapes or not. It breaks out of the loop when it escapes
 			for (iter =0; iter<=maxiter; iter++)
 			{
@@ -80,7 +80,7 @@ void main(int argc, int *argv[])
 			//if the point escapes, find the distance from the set, just incase its close to the set. if it is, it will make it part of the set.
 			if (x2+y2>=huge)
 			{
-				xder, yder = 0;
+				xder = 0; yder = 0;
 				i = 0;
 				flag = false;
 
@@ -99,11 +99,13 @@ void main(int argc, int *argv[])
 			}
 			//Assign the appropriate values to MSet in the place relating to the point in question
 			if (dist < delta)
-				MSet[iy * ny + ix] = 1;
+				MSet[iy * nx + ix] = 1;
 			else
-				MSet[iy * ny + ix] = 0;
+				MSet[iy * nx + ix] = 0;
 		}
 	}
 	//Finally write the image. This funcion is defined in tiff.c. Refer to that file for more indepth usage of libTiff in C.
 	calc_pixel_value(nx,ny,MSet,maxiter);
+	free(MSet);
+	return EXIT_SUCCESS;
 }

--- a/tiff.c
+++ b/tiff.c
@@ -17,7 +17,7 @@ extern void calc_pixel_value(int nx, int ny, int coordArray[nx*ny], int maxiter)
 	{
 		for (a = 0; a<nx; a++)
 		{
-			pointiter = coordArray[a*nx+i];
+			pointiter = coordArray[i*nx+a];
 			if (pointiter == 1)			//COLOR HERE
 				m_image_data[elecount] = 0;
 			else 
@@ -33,7 +33,7 @@ extern void calc_pixel_value(int nx, int ny, int coordArray[nx*ny], int maxiter)
 
 void write_tiff_bilevel(char * outputFilename, int m_width, int m_height, unsigned char m_image_data[m_width*m_height])
 {
-	int i;
+	//int i;<- not used
 	TIFF *outputname;
 	if((outputname = TIFFOpen(outputFilename, "w")) == NULL)
 	{


### PR DESCRIPTION
Now it doesn't.

Collapse the loops to increase the performance (OpenMP-Version)